### PR TITLE
Fix jsonb column management + partitioned table case sensitive

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PostgresORM"
 uuid = "748b5efa-ed57-4836-b183-a38105a77fdd"
 authors = ["Vincent Laugier <vincent.laugier@gmail.com>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/SchemaInfo/check_if_table_or_partition_exists.jl
+++ b/src/SchemaInfo/check_if_table_or_partition_exists.jl
@@ -3,7 +3,7 @@ function SchemaInfo.check_if_table_or_partition_exists(table::String,
                                                        dbconn::LibPQ.Connection)
     querystr = "SELECT EXISTS (
                    SELECT FROM information_schema.tables
-                   WHERE  table_name  = \$1
+                   WHERE  LOWER(table_name)  = LOWER(\$1)
                    AND    table_schema = \$2
                    );"
     queryres = execute_plain_query(querystr, [table, schema], dbconn)

--- a/src/Tool/Tool.jl
+++ b/src/Tool/Tool.jl
@@ -158,6 +158,8 @@ function get_fieldtype_from_coltype(
         attrtype = missing
     elseif (coltype == "USER-DEFINED")
         attrtype = build_enum_name_w_module(elttype)
+    elseif (coltype == "jsonb")
+        attrtype = "Dict{String, Any}"
     else
         error("Unknown type[$coltype] for table[$tablename] column[$colname]")
     end


### PR DESCRIPTION
Fix 2 issues : 
- Postgres jsonb type wasn't handled
- Unable to find existing partitioned table if the table_name contains capital letters